### PR TITLE
Add missing page_size argument

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^LICENSE\.md$
 ^README\.Rmd$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DominoDataR.Rproj
+++ b/DominoDataR.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/objectstore.R
+++ b/R/objectstore.R
@@ -27,12 +27,14 @@
 list_keys <- function(client,
                       datasource,
                       prefix = "",
-                      override = list()) {
+                      override = list(),
+                      page_size = 50) {
   datasource <- client$get_datasource(datasource)
   credentials <- DominoDataR::add_credentials(datasource$auth_type, override)
   client$list_keys(
     datasource$identifier,
     prefix,
+    page_size,
     reticulate::dict(override),
     reticulate::dict(credentials)
   )


### PR DESCRIPTION
Hi!

I am just tried to use this package and noticed that the `list_keys()` function returns an error.

```
> list_keys(client, "s3")

 Error in py_call_impl(callable, dots$args, dots$keywords) : 
  TypeError: list_keys() missing 1 required positional argument: 'credential'
```

Upon investigation I found that the Python function being called now has a `page_size` argument. I have updated the implementation of the `list_keys()` function to include a `page_size` parameter and defaulted it to 50.

Thanks, Andrew.